### PR TITLE
EC2 with a DNS entry

### DIFF
--- a/terraform/valentin/main.tf
+++ b/terraform/valentin/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
+    }
+  }
+
+  required_version = ">= 1.2.8"
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+resource "aws_instance" "app_server" {
+  ami           = "ami-09e2d756e7d78558d"
+  instance_type = "t2.micro"
+
+  tags = {
+    Name = var.instance_name
+  }
+
+  root_block_device {
+    delete_on_termination = true
+    volume_size           = 8
+    volume_type           = "gp3"
+  }
+}

--- a/terraform/valentin/outputs.tf
+++ b/terraform/valentin/outputs.tf
@@ -1,0 +1,11 @@
+
+output "instance_id" {
+  description = "ID of the EC2 instance"
+  value       = aws_instance.app_server.id
+}
+
+output "instance_public_ip" {
+  description = "Public IP address of the EC2 instance"
+  value       = aws_instance.app_server.public_ip
+}
+

--- a/terraform/valentin/route53.tf
+++ b/terraform/valentin/route53.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_zone" "valentinec2" {
+  name = "www.valentinec2.com"
+}
+
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.valentinec2.zone_id
+  name    = "www.valentinec2.com"
+  type    = "A"
+  ttl     = 300
+  records = [aws_instance.app_server.public_ip]
+}

--- a/terraform/valentin/variables.tf
+++ b/terraform/valentin/variables.tf
@@ -1,0 +1,6 @@
+variable "instance_name" {
+  description = "Value of the Name tag for the EC2 instance"
+  type        = string
+  default     = "ValentinEC2Instance"
+}
+


### PR DESCRIPTION
**Action:**
- Create an `EC2` instance in the `VPC eu-west-1` with `Public IP`, using `Terraform` code.
- Create `A DNS entry` of the `EC2` instance in the `Route53` zone.

**Motivation:**
- Get `EC2` instance in the defined zone.
- Get the necessary `DNS` entry.
- `Terraform `code practice.